### PR TITLE
Port to MC 26.1.2

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 21
+    - name: Set up JDK 25
       uses: actions/setup-java@v4
       with:
-        java-version: '21'
+        java-version: '25'
         distribution: 'temurin'
         server-id: github
         settings-path: ${{ github.workspace }}
@@ -25,7 +25,7 @@ jobs:
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582
 
     - name: Build
-      run: ./gradlew build
+      run: ./gradlew buildRelease
 
     - name: Publish artifacts
       run: ./gradlew uploadMod

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@
 * Renamed ResourceKey.location() to ResourceKey.identifier()
 * Updated Architectury Loom to 1.13, all dependencies updated
 
+### 26.1.2
+* Port to Minecraft 26.1.2
+* Updated Fabric Loom, ModDevGradle/NeoForm, and Gradle to 9.4
+* Updated Fabric API, NeoForge, MidnightLib, ModMenu dependencies
+* Adapted Fabric networking, key mapping, and Xaero's Minimap APIs
+
 ### 21.9.0
 * Port to Minecraft 1.21.9 (covers 1.21.9-1.21.10)
 * Adapted KeyMapping.Category API change (ResourceLocation-based)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ![Logo](docs/logo.png)
 
 [![Licence](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/license/mit)
-[![Java 21](https://img.shields.io/badge/java-21%2B-blue)](https://adoptium.net/temurin/releases/?version=21)
-[![Minecraft](https://img.shields.io/badge/minecraft-1.21.4-blue)](https://www.minecraft.net/article/minecraft-java-edition-1-21-4)
-[![Build status](https://img.shields.io/github/actions/workflow/status/ivkond-mc/easy-homes/gradle-publish.yml?branch=release/1.21.4)](https://github.com/ivkond-mc/easy-homes/actions/workflows/gradle-publish.yml?branch=release/1.21.4)
+[![Java 25](https://img.shields.io/badge/java-25%2B-blue)](https://adoptium.net/temurin/releases/?version=25)
+[![Minecraft](https://img.shields.io/badge/minecraft-26.1.2-blue)](https://www.minecraft.net/)
+[![Build status](https://img.shields.io/github/actions/workflow/status/ivkond-mc/easy-homes/gradle-publish.yml?branch=release/26.1.2)](https://github.com/ivkond-mc/easy-homes/actions/workflows/gradle-publish.yml?branch=release/26.1.2)
 
 ### 🏠 About
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,7 @@
 plugins {
-    id 'dev.architectury.loom' version '1.13-SNAPSHOT' apply false
-    id 'architectury-plugin' version '3.4-SNAPSHOT'
-    id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
+    id 'net.fabricmc.fabric-loom' version "${fabric_loom_version}" apply false
+    id 'net.neoforged.moddev' version "${moddevgradle_version}" apply false
     id 'com.hypherionmc.modutils.modpublisher' version '2.1.6' apply false
-}
-
-architectury {
-    minecraft = project.minecraft_version
 }
 
 allprojects {
@@ -14,13 +9,10 @@ allprojects {
 }
 
 subprojects {
-    apply plugin: 'dev.architectury.loom'
-    apply plugin: 'architectury-plugin'
+    apply plugin: 'java'
     apply plugin: 'maven-publish'
-    apply plugin: 'com.hypherionmc.modutils.modpublisher'
 
     base {
-        // Set up a suffixed format for the mod jar names, e.g. `example-fabric`.
         archivesName = "$rootProject.archives_name"
     }
 
@@ -33,52 +25,54 @@ subprojects {
         // For: MidnightLib
         maven { url "https://api.modrinth.com/maven" }
         // For: Xaero's mods
-        maven { url 'https://cursemaven.com' }
-    }
-
-    loom {
-        silentMojangMappingsLicense()
-    }
-
-    dependencies {
-        minecraft "net.minecraft:minecraft:${rootProject.minecraft_version}"
-        mappings loom.officialMojangMappings()
+        maven { url 'https://chocolateminecraft.com/maven' }
     }
 
     java {
         withSourcesJar()
 
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_25
+        targetCompatibility = JavaVersion.VERSION_25
     }
 
     tasks.withType(JavaCompile).configureEach {
-        it.options.release = 21
+        it.options.release = 25
     }
 
-    publisher {
-        apiKeys {
-            modrinth = project.findProperty("modrinth.token") ?: System.getenv("MODRINTH_TOKEN")
-            curseforge = project.findProperty("curseforge.token") ?: System.getenv("CURSE_TOKEN")
+    if (enabled_platforms.split(',').contains(project.name)) {
+        apply plugin: 'com.hypherionmc.modutils.modpublisher'
+
+        publisher {
+            apiKeys {
+                modrinth = project.findProperty("modrinth.token") ?: System.getenv("MODRINTH_TOKEN")
+                curseforge = project.findProperty("curseforge.token") ?: System.getenv("CURSE_TOKEN")
+            }
+
+            setCurseID(curseforge_id)
+            setModrinthID(modrinth_id)
+            setVersionType("release")
+            setChangelog(rootProject.file("./CHANGELOG.md"))
+            setGameVersions([minecraft_version])
+            setCurseEnvironment("both")
+            setArtifact(tasks.named("jar"))
+            setJavaVersions([JavaVersion.VERSION_25])
+            setDisableEmptyJarCheck(false)
+            setLoaders(project.name)
+            setProjectVersion("${project.version}")
+            setDisplayName("${archives_name}-${project.version}")
         }
-
-        setCurseID(curseforge_id)
-        setModrinthID(modrinth_id)
-        setVersionType("release")
-        setChangelog(rootProject.file("./CHANGELOG.md"))
-        setGameVersions([minecraft_version])
-        setCurseEnvironment("both")
-        setArtifact(remapJar)
-        setJavaVersions([JavaVersion.VERSION_21])
-        setDisableEmptyJarCheck(false)
     }
+}
+
+tasks.register('buildRelease') {
+    group 'build'
+    dependsOn(':common:build')
+    dependsOn(enabled_platforms.split(',').collect {":" + it + ":build" })
 }
 
 tasks.register('uploadMod') {
     group 'publishing'
-    // Generates something like: [':fabric:publishMod', ':neoforge:publishMod']
-    def tasks = enabled_platforms.split(',').collect {":" + it + ":publishMod" }
-    dependsOn(tasks)
+    dependsOn(enabled_platforms.split(',').collect {":" + it + ":publishMod" })
     doLast {
         print("Mods has been successfully uploaded")
     }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,16 +1,14 @@
-architectury {
-    common rootProject.enabled_platforms.split(',')
+plugins {
+    id 'net.neoforged.moddev'
+}
+
+version = "${rootProject.mod_version}-common"
+
+neoForge {
+    neoFormVersion = rootProject.neoform_version
 }
 
 dependencies {
-    // We depend on Fabric Loader here to use the Fabric @Environment annotations,
-    // which get remapped to the correct annotations on each platform.
-    // Do NOT use other classes from Fabric Loader.
-    modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
-
-    // A little bit weird, but common module may use Fabric version as dependency in 'modCompileOnly' scope
-    // See: https://github.com/TeamMidnightDust/MidnightLib/issues/74
-    modCompileOnly "maven.modrinth:midnightlib:${rootProject.midnightlib_version}-fabric"
-
-    modApi "curse.maven:xaeros-minimap-263420:${rootProject.xaeros_minimap_version}"
+    compileOnly "maven.modrinth:midnightlib:${rootProject.midnightlib_version}-fabric"
+    compileOnly "xaero.minimap:xaerominimap-common-${rootProject.minecraft_version}:${rootProject.xaeros_minimap_version}"
 }

--- a/common/src/main/java/ivkond/mc/mods/eh/EasyHomesMod.java
+++ b/common/src/main/java/ivkond/mc/mods/eh/EasyHomesMod.java
@@ -2,7 +2,6 @@ package ivkond.mc.mods.eh;
 
 import com.mojang.brigadier.CommandDispatcher;
 import eu.midnightdust.lib.config.MidnightConfig;
-import ivkond.mc.mods.eh.client.KeyPressedHandler;
 import ivkond.mc.mods.eh.commands.*;
 import ivkond.mc.mods.eh.config.EasyHomesConfig;
 import ivkond.mc.mods.eh.integration.xaero.XaerosMinimapIntegration;
@@ -10,8 +9,6 @@ import ivkond.mc.mods.eh.storage.HomeRepository;
 import ivkond.mc.mods.eh.utils.Log;
 import ivkond.mc.mods.eh.utils.PathUtils;
 import ivkond.mc.mods.eh.utils.Platform;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
@@ -41,10 +38,6 @@ public final class EasyHomesMod {
         homes.forgetAll();
     }
 
-    public static void onClientTick(Minecraft minecraft) {
-        KeyPressedHandler.handle(minecraft);
-    }
-
     public static void onPlayerLoggedIn(ServerPlayer player) {
         Log.debug("Player {} logged in. Now load configuration", player.getDisplayName().getString());
         homes.loadConfig(player.getStringUUID());
@@ -53,10 +46,6 @@ public final class EasyHomesMod {
     public static void onPlayerLoggedOut(ServerPlayer player) {
         Log.debug("Player {} logged out. Now persist and clear configuration", player.getDisplayName().getString());
         homes.forgetConfig(player.getStringUUID());
-    }
-
-    public static Screen createConfigurationScreen(Screen parent) {
-        return MidnightConfig.getScreen(parent, MOD_ID);
     }
 
     public static void registerCommands(CommandDispatcher<CommandSourceStack> dispatcher) {

--- a/common/src/main/java/ivkond/mc/mods/eh/commands/BackCommand.java
+++ b/common/src/main/java/ivkond/mc/mods/eh/commands/BackCommand.java
@@ -31,7 +31,7 @@ public class BackCommand {
 
         String lastVisitedHome = homes.getLastVisitedHome(player.getStringUUID());
         if (lastVisitedHome == null) {
-            player.displayClientMessage(I18N.errorNoLastVisitedHome(), true);
+            player.sendOverlayMessage(I18N.errorNoLastVisitedHome());
             return 0;
         }
 

--- a/common/src/main/java/ivkond/mc/mods/eh/commands/DelHomeCommand.java
+++ b/common/src/main/java/ivkond/mc/mods/eh/commands/DelHomeCommand.java
@@ -40,12 +40,12 @@ public class DelHomeCommand {
         Log.debug("Delete players {} home {}", player.getDisplayName().getString(), name);
 
         if (HomeUtils.isInvalidName(name)) {
-            player.displayClientMessage(I18N.errorInvalidHomeName(name), true);
+            player.sendOverlayMessage(I18N.errorInvalidHomeName(name));
             return 0;
         }
 
         if (!homes.exists(playerId, name)) {
-            player.displayClientMessage(I18N.errorHomeNotFound(name), true);
+            player.sendOverlayMessage(I18N.errorHomeNotFound(name));
             return 0;
         }
 
@@ -54,7 +54,7 @@ public class DelHomeCommand {
         HomeDeletedPayload payload = new HomeDeletedPayload(name);
         PacketSender.send(player, payload);
 
-        player.displayClientMessage(I18N.commandDelHomeSuccess(name), true);
+        player.sendOverlayMessage(I18N.commandDelHomeSuccess(name));
 
         return Command.SINGLE_SUCCESS;
     }

--- a/common/src/main/java/ivkond/mc/mods/eh/commands/HomeCommand.java
+++ b/common/src/main/java/ivkond/mc/mods/eh/commands/HomeCommand.java
@@ -60,7 +60,7 @@ public class HomeCommand {
         Log.debug("Teleporting {} to home {}", player.getName().getString(), homeName);
 
         if (HomeUtils.isInvalidName(homeName)) {
-            player.displayClientMessage(I18N.errorInvalidHomeName(homeName), true);
+            player.sendOverlayMessage(I18N.errorInvalidHomeName(homeName));
             return 0;
         }
 
@@ -74,20 +74,20 @@ public class HomeCommand {
         ServerLevel currentLevel = stack.getLevel();
 
         if (player.isPassenger() && player.canControlVehicle()) {
-            player.displayClientMessage(I18N.errorPlayerMounted(), true);
+            player.sendOverlayMessage(I18N.errorPlayerMounted());
             return false;
         }
 
         HomeLocation home = homes.findHome(playerId, homeName);
         if (home == null) {
-            player.displayClientMessage(I18N.errorHomeNotFound(homeName), true);
+            player.sendOverlayMessage(I18N.errorHomeNotFound(homeName));
             return false;
         }
 
         if (!player.isCreative()) {
             Duration cooldown = homes.getCooldown(playerId);
             if (cooldown.isPositive()) {
-                player.displayClientMessage(I18N.commandHomeLocked(cooldown), true);
+                player.sendOverlayMessage(I18N.commandHomeLocked(cooldown));
                 return false;
             }
         }
@@ -96,14 +96,14 @@ public class HomeCommand {
         ResourceKey<Level> levelKey = ResourceKey.create(Registries.DIMENSION, levelLocation);
         ServerLevel targetLevel = stack.getServer().getLevel(levelKey);
         if (targetLevel == null) {
-            player.displayClientMessage(I18N.errorUnknownLevel(home.dimension()), true);
+            player.sendOverlayMessage(I18N.errorUnknownLevel(home.dimension()));
             return false;
         }
 
         // TeleportCommand#performTeleport
         BlockPos blockPos = BlockPos.containing(home.x(), home.y(), home.z());
         if (!ServerLevel.isInSpawnableBounds(blockPos)) {
-            player.displayClientMessage(I18N.errorInvalidPosition(), true);
+            player.sendOverlayMessage(I18N.errorInvalidPosition());
             return false;
         }
 
@@ -113,7 +113,7 @@ public class HomeCommand {
 
         homes.onTeleported(playerId, homeName);
 
-        player.displayClientMessage(I18N.commandHomeSuccess(homeName), true);
+        player.sendOverlayMessage(I18N.commandHomeSuccess(homeName));
         return true;
     }
 

--- a/common/src/main/java/ivkond/mc/mods/eh/commands/RenHomeCommand.java
+++ b/common/src/main/java/ivkond/mc/mods/eh/commands/RenHomeCommand.java
@@ -40,13 +40,13 @@ public class RenHomeCommand {
 
         String oldName = context.getArgument("old_name", String.class);
         if (HomeUtils.isInvalidName(oldName)) {
-            player.displayClientMessage(I18N.errorInvalidHomeName(oldName), true);
+            player.sendOverlayMessage(I18N.errorInvalidHomeName(oldName));
             return 0;
         }
 
         String newName = context.getArgument("new_name", String.class);
         if (HomeUtils.isInvalidName(newName)) {
-            player.displayClientMessage(I18N.errorInvalidHomeName(newName), true);
+            player.sendOverlayMessage(I18N.errorInvalidHomeName(newName));
             return 0;
         }
 
@@ -54,7 +54,7 @@ public class RenHomeCommand {
 
         boolean oldHomeExists = homes.exists(playerId, oldName);
         if (!oldHomeExists) {
-            player.displayClientMessage(I18N.errorHomeNotFound(oldName), true);
+            player.sendOverlayMessage(I18N.errorHomeNotFound(oldName));
             return 0;
         }
 
@@ -63,7 +63,7 @@ public class RenHomeCommand {
         HomeRenamedPayload payload = new HomeRenamedPayload(oldName, newName);
         PacketSender.send(player, payload);
 
-        player.displayClientMessage(I18N.commandRenHomeSuccess(oldName, newName), true);
+        player.sendOverlayMessage(I18N.commandRenHomeSuccess(oldName, newName));
 
         return Command.SINGLE_SUCCESS;
     }

--- a/common/src/main/java/ivkond/mc/mods/eh/commands/SetHomeCommand.java
+++ b/common/src/main/java/ivkond/mc/mods/eh/commands/SetHomeCommand.java
@@ -54,7 +54,7 @@ public class SetHomeCommand {
         }
 
         if (HomeUtils.isInvalidName(homeName)) {
-            player.displayClientMessage(I18N.errorInvalidHomeName(homeName), true);
+            player.sendOverlayMessage(I18N.errorInvalidHomeName(homeName));
             return 0;
         }
 
@@ -63,7 +63,7 @@ public class SetHomeCommand {
         boolean existingHome = homes.exists(playerId, homeName);
 
         if (!player.isCreative() && !existingHome && homes.isMaxHomesReached(playerId)) {
-            player.displayClientMessage(I18N.commandSetHomeMaxHomesReached(), true);
+            player.sendOverlayMessage(I18N.commandSetHomeMaxHomesReached());
             return 0;
         }
 
@@ -76,7 +76,7 @@ public class SetHomeCommand {
         HomeCreatedPayload payload = new HomeCreatedPayload(homeName, location);
         PacketSender.send(player, payload);
 
-        player.displayClientMessage(I18N.commandSetHomeSuccess(homeName, existingHome), true);
+        player.sendOverlayMessage(I18N.commandSetHomeSuccess(homeName, existingHome));
 
         return Command.SINGLE_SUCCESS;
     }

--- a/common/src/main/java/ivkond/mc/mods/eh/integration/xaero/XaerosMinimapIntegration.java
+++ b/common/src/main/java/ivkond/mc/mods/eh/integration/xaero/XaerosMinimapIntegration.java
@@ -3,12 +3,13 @@ package ivkond.mc.mods.eh.integration.xaero;
 import ivkond.mc.mods.eh.domain.HomeLocation;
 import ivkond.mc.mods.eh.utils.Log;
 import ivkond.mc.mods.eh.utils.Platform;
-import xaero.common.core.XaeroMinimapCore;
+import xaero.common.XaeroMinimapSession;
 import xaero.common.minimap.waypoints.Waypoint;
-import xaero.common.minimap.waypoints.WaypointsManager;
+import xaero.hud.minimap.module.MinimapSession;
 import xaero.hud.minimap.waypoint.WaypointColor;
 import xaero.hud.minimap.waypoint.WaypointPurpose;
-import xaero.minimap.XaeroMinimap;
+import xaero.hud.minimap.waypoint.set.WaypointSet;
+import xaero.hud.minimap.world.MinimapWorld;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -29,8 +30,13 @@ public class XaerosMinimapIntegration {
             return;
         }
 
-        WaypointsManager waypointsManager = XaeroMinimapCore.currentSession.getWaypointsManager();
-        ArrayList<Waypoint> waypoints = waypointsManager.getWaypoints().getList();
+        MinimapWorld world = getCurrentWorld();
+        if (world == null) {
+            return;
+        }
+
+        WaypointSet waypointSet = world.getCurrentWaypointSet();
+        List<Waypoint> waypoints = copyWaypoints(waypointSet);
 
         Waypoint existing = findWaypointByHomeName(waypoints, homeName);
         if (existing != null) {
@@ -50,10 +56,10 @@ public class XaerosMinimapIntegration {
                     WaypointPurpose.NORMAL,
                     false
             );
-            waypoints.add(newWaypoint);
+            waypointSet.add(newWaypoint);
         }
 
-        saveWaypoints(waypointsManager);
+        saveWaypoints(world);
     }
 
     public static void onHomeRenamed(String oldHomeName, String newHomeName) {
@@ -61,10 +67,12 @@ public class XaerosMinimapIntegration {
             return;
         }
 
-        WaypointsManager waypointsManager = XaeroMinimapCore.currentSession.getWaypointsManager();
-        ArrayList<Waypoint> waypoints = waypointsManager.getWaypoints().getList();
+        MinimapWorld world = getCurrentWorld();
+        if (world == null) {
+            return;
+        }
 
-        Waypoint waypoint = findWaypointByHomeName(waypoints, oldHomeName);
+        Waypoint waypoint = findWaypointByHomeName(copyWaypoints(world.getCurrentWaypointSet()), oldHomeName);
         if (waypoint == null) {
             return;
         }
@@ -72,7 +80,7 @@ public class XaerosMinimapIntegration {
         waypoint.setName(WAYPOINT_NAME.formatted(newHomeName));
         waypoint.setInitials(newHomeName.substring(0, 1));
 
-        saveWaypoints(waypointsManager);
+        saveWaypoints(world);
     }
 
     public static void onHomeDeleted(String homeName) {
@@ -80,18 +88,52 @@ public class XaerosMinimapIntegration {
             return;
         }
 
-        WaypointsManager waypointsManager = XaeroMinimapCore.currentSession.getWaypointsManager();
-        List<Waypoint> waypoints = waypointsManager.getWaypoints().getList();
+        MinimapWorld world = getCurrentWorld();
+        if (world == null) {
+            return;
+        }
 
+        WaypointSet waypointSet = world.getCurrentWaypointSet();
         String waypointName = WAYPOINT_NAME.formatted(homeName);
-        waypoints.removeIf(waypoint -> waypoint.getName().equals(waypointName));
+        for (Waypoint waypoint : copyWaypoints(waypointSet)) {
+            if (waypoint.getName().equals(waypointName)) {
+                waypointSet.remove(waypoint);
+            }
+        }
 
-        saveWaypoints(waypointsManager);
+        saveWaypoints(world);
     }
 
-    private static void saveWaypoints(WaypointsManager waypointsManager) {
+    private static MinimapWorld getCurrentWorld() {
+        MinimapSession session = getMinimapSession();
+        if (session == null) {
+            return null;
+        }
+        return session.getWorldManager().getCurrentWorld();
+    }
+
+    private static MinimapSession getMinimapSession() {
+        XaeroMinimapSession session = XaeroMinimapSession.getCurrentSession();
+        if (session == null || session.getMinimapProcessor() == null) {
+            return null;
+        }
+        return session.getMinimapProcessor().getSession();
+    }
+
+    private static List<Waypoint> copyWaypoints(WaypointSet waypointSet) {
+        List<Waypoint> waypoints = new ArrayList<>();
+        waypointSet.getWaypoints().forEach(waypoints::add);
+        return waypoints;
+    }
+
+    private static void saveWaypoints(MinimapWorld world) {
+        MinimapSession session = getMinimapSession();
+        if (session == null) {
+            return;
+        }
+
         try {
-            XaeroMinimap.instance.getSettings().saveWaypoints(waypointsManager.getCurrentWorld());
+            session.getWorldManagerIO().saveWorld(world);
         } catch (IOException e) {
             Log.error("Unable to save waypoints", e);
         }

--- a/common/src/main/java/ivkond/mc/mods/eh/integration/xaero/XaerosMinimapIntegration.java
+++ b/common/src/main/java/ivkond/mc/mods/eh/integration/xaero/XaerosMinimapIntegration.java
@@ -13,7 +13,6 @@ import xaero.hud.minimap.world.MinimapWorld;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
 
 public class XaerosMinimapIntegration {
     public static final String MOD_ID = "xaerominimap";
@@ -36,7 +35,7 @@ public class XaerosMinimapIntegration {
         }
 
         WaypointSet waypointSet = world.getCurrentWaypointSet();
-        List<Waypoint> waypoints = copyWaypoints(waypointSet);
+        ArrayList<Waypoint> waypoints = copyWaypoints(waypointSet);
 
         Waypoint existing = findWaypointByHomeName(waypoints, homeName);
         if (existing != null) {
@@ -120,8 +119,8 @@ public class XaerosMinimapIntegration {
         return session.getMinimapProcessor().getSession();
     }
 
-    private static List<Waypoint> copyWaypoints(WaypointSet waypointSet) {
-        List<Waypoint> waypoints = new ArrayList<>();
+    private static ArrayList<Waypoint> copyWaypoints(WaypointSet waypointSet) {
+        ArrayList<Waypoint> waypoints = new ArrayList<>();
         waypointSet.getWaypoints().forEach(waypoints::add);
         return waypoints;
     }
@@ -139,7 +138,7 @@ public class XaerosMinimapIntegration {
         }
     }
 
-    private static Waypoint findWaypointByHomeName(List<Waypoint> waypoints, String homeName) {
+    private static Waypoint findWaypointByHomeName(Iterable<Waypoint> waypoints, String homeName) {
         String waypointName = WAYPOINT_NAME.formatted(homeName);
         for (Waypoint waypoint : waypoints) {
             if (waypoint.getComparisonName().equals(waypointName)) {

--- a/common/src/main/java/ivkond/mc/mods/eh/integration/xaero/XaerosMinimapIntegration.java
+++ b/common/src/main/java/ivkond/mc/mods/eh/integration/xaero/XaerosMinimapIntegration.java
@@ -95,7 +95,7 @@ public class XaerosMinimapIntegration {
         WaypointSet waypointSet = world.getCurrentWaypointSet();
         String waypointName = WAYPOINT_NAME.formatted(homeName);
         for (Waypoint waypoint : copyWaypoints(waypointSet)) {
-            if (waypoint.getName().equals(waypointName)) {
+            if (waypoint.getComparisonName().equals(waypointName)) {
                 waypointSet.remove(waypoint);
             }
         }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -22,8 +22,8 @@ repositories {
 dependencies {
     minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
 
-    // Minecraft 26.1+ uses unobfuscated Loom.
-    // Keep standard Gradle configurations; modImplementation/mappings are unavailable here.
+    // Fabric's Minecraft 26.1+ porting guide requires unobfuscated Loom builds to remove
+    // mappings and replace modImplementation/modCompileOnly/modApi with implementation/compileOnly/api.
     implementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
 
     // Fabric API. This is technically optional, but you probably want it anyway.

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -22,6 +22,8 @@ repositories {
 dependencies {
     minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
 
+    // Minecraft 26.1+ uses unobfuscated Loom.
+    // Keep standard Gradle configurations; modImplementation/mappings are unavailable here.
     implementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
 
     // Fabric API. This is technically optional, but you probably want it anyway.

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,28 +1,13 @@
 plugins {
-    id 'com.github.johnrengelman.shadow'
+    id 'net.fabricmc.fabric-loom'
 }
 
-version = "${mod_version}-fabric"
+version = "${rootProject.mod_version}-fabric"
 
-architectury {
-    platformSetupLoomIde()
-    fabric()
-}
-
-configurations {
-    common {
-        canBeResolved = true
-        canBeConsumed = false
-    }
-    compileClasspath.extendsFrom common
-    runtimeClasspath.extendsFrom common
-    developmentFabric.extendsFrom common
-
-    // Files in this configuration will be bundled into your mod using the Shadow plugin.
-    // Don't use the `shadow` configuration from the plugin itself as it's meant for excluding files.
-    shadowBundle {
-        canBeResolved = true
-        canBeConsumed = false
+sourceSets {
+    main {
+        java.srcDir '../common/src/main/java'
+        resources.srcDir '../common/src/main/resources'
     }
 }
 
@@ -35,16 +20,17 @@ repositories {
 }
 
 dependencies {
-    modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
+    minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
+
+    implementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
 
     // Fabric API. This is technically optional, but you probably want it anyway.
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_api_version}"
-    modImplementation "com.terraformersmc:modmenu:${project.modmenu_version}"
+    implementation "net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_api_version}"
+    implementation "com.terraformersmc:modmenu:${project.modmenu_version}"
 
-    modImplementation include ("maven.modrinth:midnightlib:${project.midnightlib_version}-fabric")
+    implementation include ("maven.modrinth:midnightlib:${rootProject.midnightlib_version}-fabric")
 
-    common(project(path: ':common', configuration: 'namedElements')) { transitive false }
-    shadowBundle project(path: ':common', configuration: 'transformProductionFabric')
+    compileOnly "xaero.minimap:xaerominimap-common-${rootProject.minecraft_version}:${rootProject.xaeros_minimap_version}"
 }
 
 processResources {
@@ -55,28 +41,5 @@ processResources {
 
     filesMatching('fabric.mod.json') {
         expand props
-    }
-}
-
-shadowJar {
-    configurations = [project.configurations.shadowBundle]
-    archiveClassifier = 'dev-shadow'
-}
-
-remapJar {
-    inputFile.set shadowJar.archiveFile
-}
-
-publisher {
-    setLoaders("fabric")
-    setProjectVersion("${project.version}")
-    setDisplayName("${archives_name}-${project.version}")
-
-    modrinthDepends {
-        optional "modmenu"
-    }
-
-    curseDepends {
-        optional "modmenu"
     }
 }

--- a/fabric/gradle.properties
+++ b/fabric/gradle.properties
@@ -1,1 +1,1 @@
-modmenu_version = 17.0.0
+modmenu_version = 18.0.0-beta.1

--- a/fabric/src/main/java/ivkond/mc/mods/eh/fabric/EasyHomesModFabric.java
+++ b/fabric/src/main/java/ivkond/mc/mods/eh/fabric/EasyHomesModFabric.java
@@ -33,8 +33,8 @@ public final class EasyHomesModFabric implements ModInitializer {
                         EasyHomesMod.registerCommands(dispatcher)
         );
 
-        PayloadTypeRegistry.playS2C().register(HomeCreatedPayload.ID, HomeCreatedPayload.CODEC);
-        PayloadTypeRegistry.playS2C().register(HomeDeletedPayload.ID, HomeDeletedPayload.CODEC);
-        PayloadTypeRegistry.playS2C().register(HomeRenamedPayload.ID, HomeRenamedPayload.CODEC);
+        PayloadTypeRegistry.clientboundPlay().register(HomeCreatedPayload.ID, HomeCreatedPayload.CODEC);
+        PayloadTypeRegistry.clientboundPlay().register(HomeDeletedPayload.ID, HomeDeletedPayload.CODEC);
+        PayloadTypeRegistry.clientboundPlay().register(HomeRenamedPayload.ID, HomeRenamedPayload.CODEC);
     }
 }

--- a/fabric/src/main/java/ivkond/mc/mods/eh/fabric/client/EasyHomesModFabricClient.java
+++ b/fabric/src/main/java/ivkond/mc/mods/eh/fabric/client/EasyHomesModFabricClient.java
@@ -1,6 +1,6 @@
 package ivkond.mc.mods.eh.fabric.client;
 
-import ivkond.mc.mods.eh.EasyHomesMod;
+import ivkond.mc.mods.eh.client.KeyPressedHandler;
 import ivkond.mc.mods.eh.client.KeyMappings;
 import ivkond.mc.mods.eh.integration.xaero.XaerosMinimapIntegration;
 import ivkond.mc.mods.eh.network.HomeCreatedPayload;
@@ -8,17 +8,17 @@ import ivkond.mc.mods.eh.network.HomeDeletedPayload;
 import ivkond.mc.mods.eh.network.HomeRenamedPayload;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
-import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 
 public final class EasyHomesModFabricClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
-        KeyBindingHelper.registerKeyBinding(KeyMappings.TP_TO_DEFAULT_HOME);
-        KeyBindingHelper.registerKeyBinding(KeyMappings.SET_NEW_HOME);
+        KeyMappingHelper.registerKeyMapping(KeyMappings.TP_TO_DEFAULT_HOME);
+        KeyMappingHelper.registerKeyMapping(KeyMappings.SET_NEW_HOME);
 
-        ClientTickEvents.END_CLIENT_TICK.register(EasyHomesMod::onClientTick);
+        ClientTickEvents.END_CLIENT_TICK.register(KeyPressedHandler::handle);
 
         ClientPlayConnectionEvents.INIT.register((handler, client) -> {
             ClientPlayNetworking.registerReceiver(HomeCreatedPayload.ID, (payload, ctx) ->

--- a/fabric/src/main/java/ivkond/mc/mods/eh/fabric/client/ModMenuConfiguration.java
+++ b/fabric/src/main/java/ivkond/mc/mods/eh/fabric/client/ModMenuConfiguration.java
@@ -2,14 +2,15 @@ package ivkond.mc.mods.eh.fabric.client;
 
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
+import eu.midnightdust.lib.config.MidnightConfig;
+import ivkond.mc.mods.eh.EasyHomesMod;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import ivkond.mc.mods.eh.EasyHomesMod;
 
 @Environment(EnvType.CLIENT)
 public class ModMenuConfiguration implements ModMenuApi {
     @Override
     public ConfigScreenFactory<?> getModConfigScreenFactory() {
-        return EasyHomesMod::createConfigurationScreen;
+        return parent -> MidnightConfig.getScreen(parent, EasyHomesMod.MOD_ID);
     }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -30,8 +30,8 @@
   ],
   "depends": {
     "fabricloader": ">=${fabric_loader_version}",
-    "minecraft": "~${minecraft_version}",
-    "java": ">=21",
+    "minecraft": "${minecraft_dependency}",
+    "java": ">=25",
     "fabric-api": "*"
   },
   "suggests": {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ curseforge_id = 1163866
 
 # Mod properties
 mod_id = easy_homes
-mod_version = 21.11.0
+mod_version = 26.1.2
 mod_name = Easy Homes
 mod_author = ivkond
 mod_description = Easy and lightweight /sethome mod
@@ -18,14 +18,20 @@ archives_name = easy_homes
 enabled_platforms = fabric,neoforge
 
 # Minecraft properties
-minecraft_version = 1.21.11
+minecraft_version = 26.1.2
+minecraft_dependency = ~26.1.2
+minecraft_version_range = [26.1.2,)
 
 # Dependencies
-fabric_loader_version = 0.18.4
-fabric_api_version = 0.141.3+1.21.11
-neoforge_version = 21.11.38-beta
+fabric_loader_version = 0.19.2
+fabric_api_version = 0.150.0+26.1.2
+fabric_loom_version = 1.16.3
+moddevgradle_version = 2.0.141
+neoform_version = 26.1.2-1
+neoforge_version = 26.1.2.71
+neoforge_version_range = [26.1.2,)
 
 # Mods
 # https://www.midnightdust.eu/wiki/midnightlib/
-midnightlib_version = 1.9.2+1.21.11
-xaeros_minimap_version = 6012867
+midnightlib_version = 1.9.3+26.1
+xaeros_minimap_version = 25.3.14

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -1,28 +1,13 @@
 plugins {
-    id 'com.github.johnrengelman.shadow'
+    id 'net.neoforged.moddev'
 }
 
-version = "${mod_version}-neoforge"
+version = "${rootProject.mod_version}-neoforge"
 
-architectury {
-    platformSetupLoomIde()
-    neoForge()
-}
-
-configurations {
-    common {
-        canBeResolved = true
-        canBeConsumed = false
-    }
-    compileClasspath.extendsFrom common
-    runtimeClasspath.extendsFrom common
-    developmentNeoForge.extendsFrom common
-
-    // Files in this configuration will be bundled into your mod using the Shadow plugin.
-    // Don't use the `shadow` configuration from the plugin itself as it's meant for excluding files.
-    shadowBundle {
-        canBeResolved = true
-        canBeConsumed = false
+sourceSets {
+    main {
+        java.srcDir '../common/src/main/java'
+        resources.srcDir '../common/src/main/resources'
     }
 }
 
@@ -33,13 +18,14 @@ repositories {
     }
 }
 
-dependencies {
-    neoForge "net.neoforged:neoforge:${rootProject.neoforge_version}"
+neoForge {
+    version = rootProject.neoforge_version
 
-    modImplementation include ("maven.modrinth:midnightlib:${project.midnightlib_version}-neoforge")
-
-    common(project(path: ':common', configuration: 'namedElements')) { transitive false }
-    shadowBundle project(path: ':common', configuration: 'transformProductionNeoForge')
+    mods {
+        easy_homes {
+            sourceSet sourceSets.main
+        }
+    }
 }
 
 processResources {
@@ -53,17 +39,13 @@ processResources {
     }
 }
 
-shadowJar {
-    configurations = [project.configurations.shadowBundle]
-    archiveClassifier = 'dev-shadow'
-}
+dependencies {
+    jarJar(implementation("maven.modrinth:midnightlib:${rootProject.midnightlib_version}-neoforge")) {
+        version {
+            strictly "[${rootProject.midnightlib_version}-neoforge,)"
+            prefer "${rootProject.midnightlib_version}-neoforge"
+        }
+    }
 
-remapJar {
-    inputFile.set shadowJar.archiveFile
-}
-
-publisher {
-    setLoaders("neoforge")
-    setProjectVersion("${project.version}")
-    setDisplayName("${archives_name}-${project.version}")
+    compileOnly "xaero.minimap:xaerominimap-common-${rootProject.minecraft_version}:${rootProject.xaeros_minimap_version}"
 }

--- a/neoforge/src/main/java/ivkond/mc/mods/eh/neoforge/EasyHomesModNeoForge.java
+++ b/neoforge/src/main/java/ivkond/mc/mods/eh/neoforge/EasyHomesModNeoForge.java
@@ -1,6 +1,7 @@
 package ivkond.mc.mods.eh.neoforge;
 
 import com.mojang.brigadier.CommandDispatcher;
+import eu.midnightdust.lib.config.MidnightConfig;
 import ivkond.mc.mods.eh.EasyHomesMod;
 import ivkond.mc.mods.eh.integration.xaero.XaerosMinimapIntegration;
 import ivkond.mc.mods.eh.neoforge.impl.NeoForgePlatform;
@@ -39,7 +40,7 @@ public final class EasyHomesModNeoForge {
     private static void initConfigurationScreen(ModContainer container) {
         container.registerExtensionPoint(
                 IConfigScreenFactory.class,
-                (c, parent) -> EasyHomesMod.createConfigurationScreen(parent)
+                (c, parent) -> MidnightConfig.getScreen(parent, EasyHomesMod.MOD_ID)
         );
     }
 

--- a/neoforge/src/main/java/ivkond/mc/mods/eh/neoforge/client/ClientEventBusSubscriber.java
+++ b/neoforge/src/main/java/ivkond/mc/mods/eh/neoforge/client/ClientEventBusSubscriber.java
@@ -7,6 +7,7 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
 import ivkond.mc.mods.eh.EasyHomesMod;
+import ivkond.mc.mods.eh.client.KeyPressedHandler;
 import ivkond.mc.mods.eh.client.KeyMappings;
 
 public class ClientEventBusSubscriber {
@@ -15,7 +16,7 @@ public class ClientEventBusSubscriber {
         @SubscribeEvent
         public static void onClientTick(ClientTickEvent.Post event) {
             Minecraft instance = Minecraft.getInstance();
-            EasyHomesMod.onClientTick(instance);
+            KeyPressedHandler.handle(instance);
         }
     }
 

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -14,14 +14,14 @@ logoFile = "assets/easy_homes/icon.png"
 [[dependencies.${mod_id}]]
 modId = "neoforge"
 type = "required"
-versionRange = "[21.11,)"
+versionRange = "${neoforge_version_range}"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.${mod_id}]]
 modId = "minecraft"
 type = "required"
-versionRange = "[${minecraft_version},)"
+versionRange = "${minecraft_version_range}"
 ordering = "NONE"
 side = "BOTH"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,9 +1,8 @@
 pluginManagement {
     repositories {
         maven { url "https://maven.fabricmc.net/" }
-        maven { url "https://maven.architectury.dev/" }
-        maven { url "https://files.minecraftforge.net/maven/" }
         maven { url "https://maven.firstdark.dev/releases" }
+        maven { url "https://maven.neoforged.net/releases" }
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
## Summary

Ports Easy Homes to Minecraft 26.1.2 while keeping the existing common/Fabric/NeoForge project layout aligned with `release/1.21.11`.

## Changes

- Updates the Gradle wrapper and build toolchain for Java 25 / Minecraft 26.1.2.
- Replaces the outdated Architectury Loom setup with Fabric Loom for Fabric and ModDevGradle/NeoForm for common and NeoForge builds.
- Updates Fabric API, Fabric Loader, NeoForge, MidnightLib, ModMenu, and Xaero's Minimap dependencies.
- Adapts Fabric networking/key mapping, overlay chat messages, and Xaero waypoint APIs for the new Minecraft version.
- Keeps the existing key bindings and generated home-name behavior unchanged.

## Validation

- Built with JDK 25: `./gradlew.bat buildRelease --stacktrace`
- Verified publish task wiring without uploading: `./gradlew.bat uploadMod --dry-run`
- Confirmed tracked file list matches `upstream/release/1.21.11`.

## Notes

- Gradle still reports existing deprecation warnings for Gradle 10 compatibility.
- Xaero integration compiles with deprecation warnings because the available API still exposes deprecated members.
